### PR TITLE
Use real pointer and fix sdiec

### DIFF
--- a/src/fileio.h
+++ b/src/fileio.h
@@ -3,9 +3,9 @@
 
 #include <stdint.h>
 
-char *fileio_getcwd(char buf[], uint8_t size);
+char *fileio_getcwd(char *buf, uint8_t size);
 
-int8_t fileio_version(char buf[], uint8_t size);
+int8_t fileio_version(char *buf, uint8_t size);
 
 int8_t fileio_chdir(const char *dir);
 int8_t fileio_mkdir(const char *dir);

--- a/src/parse.c
+++ b/src/parse.c
@@ -90,7 +90,7 @@ uint8_t parse_command(char *cmd, char **argv, uint8_t args) {
   while ((t >= s) && (*t && (*t == ' '))) *t-- = '\0'; /* trim end */
 
   for (i=0; i<args; i++) {
-    argv[i] = '\0';
+    argv[i] = NULL;
   }
 
   while (*s) {

--- a/src/sdiec.c
+++ b/src/sdiec.c
@@ -115,7 +115,7 @@ int8_t fileio_ls(uint8_t flags, const char *path) {
   uint8_t col, listlong = 0, listall = 0, columns = 2;
   uint8_t files = 1, dev = getcurrentdevice();
   struct cbm_dirent entry;
-  char *name, *type;
+  char *name, type;
   size_t size;
 
   if (path[0] == '.' && !path[1]) {


### PR DESCRIPTION
gcc -c -MMD -MP -O -g3 -Wno-format-security -DVERSION=0.0.2 -DGCC -DPOSIX -DHAVE_FILEIO -DHAVE_HISTORY -DHAVE_HINTS -DHAVE_COMPLETION -DHAVE_OSD -DTOOLCHAIN=gcc -DMACHINE=posix -o parse.o parse.c
parse.c:93:15: warning: expression which evaluates to zero treated as a null pointer constant of type 'char *' [-Wnon-literal-null-conversion]
    argv[i] = '\0';
              ^~~~
1 warning generated.